### PR TITLE
Séparation entre prettier et lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "start": "ng serve",
     "build": "ng build",
     "test": "ng test",
-    "lint": "ng lint && prettier -l \"**/*.ts\"",
-    "lint-fix": "ng lint --fix && prettier \"**/*.ts\" --write",
+    "lint": "ng lint \"**/*.ts\"",
+    "lint-fix": "ng lint --fix \"**/*.ts\" --write",
+    "prettier-fix": "prettier \"**/*.ts\" --write",
     "e2e": "ng e2e"
   },
   "private": true,


### PR DESCRIPTION
prettier sert à formatter le code source. il est séparé pour qu'on puisse avoir le choix de faire l'indentation en respectant le règle de lint ou faire juste du formatage selon le règle de codage normal.