### PR TITLE
correction du probleme de lien quand on fait une modification 

### DIFF
--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -1,4 +1,13 @@
-import { Routes, RouterModule } from '@angular/router';
+import {
+  AddAnnotatorComponent,
+  AddCategoryComponent,
+  AddCorpusComponent,
+  CreateProjectComponent
+} from './components';
+import { ProjectManagerComponent, UserManagerComponent } from './adm';
+import { RouterModule, Routes } from '@angular/router';
+
+import { AnnotationComponent } from './annotation/index';
 import { AuthGuard } from './shared/security/auth.guard';
 import { HomeComponent } from './home/home.component';
 import { HomeWelcomeComponent } from './home-welcome/home-welcome.component';
@@ -7,14 +16,6 @@ import { LoginComponent } from './login';
 import { PageNotFoundComponent } from './not-found/not-found.component';
 import { ProjectComponent } from './components/index';
 import { RegisterComponent } from './register';
-import { AnnotationComponent } from './annotation/index';
-import {
-  CreateProjectComponent,
-  AddCategoryComponent,
-  AddCorpusComponent,
-  AddAnnotatorComponent
-} from './components';
-import { ProjectManagerComponent, UserManagerComponent } from './adm';
 import { UserComponent } from './adm';
 
 const appRoutes: Routes = [
@@ -50,5 +51,5 @@ const appRoutes: Routes = [
 ];
 
 export const routing = RouterModule.forRoot(
-  appRoutes /*, { enableTracing: true }*/
+  appRoutes, { useHash: false } /*, { enableTracing: true }*/
 );

--- a/src/index.html
+++ b/src/index.html
@@ -1,14 +1,18 @@
 <!doctype html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8">
   <title>UQO annotator</title>
-  <script>document.write('<base href="' + document.location + '" />');</script>
+  <base href="./">
+  <!-- <script>document.write('<base href="' + document.location + '" />');</script> -->
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
-  </head>
+</head>
+
 <body>
   <app-root></app-root>
 </body>
+
 </html>


### PR DESCRIPTION
quand on rafraichit la page ou on fait une modification dans IDE, avant il amène à la page d'accueil et parfois il copie d'ancien lien. 
le scénario remarquait après modification `localhost:4200/project/project`

Cette correction est faite pour éviter de faire une répétition du même lien.