### PR TITLE
 Générateur de documentation et de couverture de documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@
 npm-debug.log
 testem.log
 /typings
+/documentation
 
 # e2e
 /e2e/*.js

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prettier-fix": "prettier \"**/*.ts\" --write",
     "e2e": "ng e2e",
     "coverage": "ng test --code-coverage=true",
-    "compodoc": "./node_modules/.bin/compodoc -p src/tsconfig.app.json",
+    "docs": "./node_modules/.bin/compodoc -p src/tsconfig.app.json -d docs",
     "docs:serve": "compodoc -p src/tsconfig.app.json -d docs -s"
   },
   "private": true,

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "prettier-fix": "prettier \"**/*.ts\" --write",
     "e2e": "ng e2e",
     "coverage": "ng test --code-coverage=true",
-    "docs": "./node_modules/.bin/compodoc -p src/tsconfig.app.json -d docs",
-    "docs:serve": "compodoc -p src/tsconfig.app.json -d docs -s"
+    "docs": "./node_modules/.bin/compodoc -p src/tsconfig.app.json -d documentation",
+    "docs:serve": "compodoc -p src/tsconfig.app.json -d documentation -s"
   },
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "lint-fix": "ng lint --fix \"**/*.ts\" --write",
     "prettier-fix": "prettier \"**/*.ts\" --write",
     "e2e": "ng e2e",
-    "coverage": "ng test --code-coverage=true"
+    "coverage": "ng test --code-coverage=true",
+    "compodoc": "./node_modules/.bin/compodoc -p src/tsconfig.app.json",
+    "docs:serve": "compodoc -p src/tsconfig.app.json -d docs -s"
   },
   "private": true,
   "dependencies": {
@@ -42,6 +44,7 @@
     "@angular/cli": "^1.7.1",
     "@angular/compiler-cli": "^5.2.9",
     "@angular/language-service": "^5.2.9",
+    "@compodoc/compodoc": "^1.1.5",
     "@types/jasmine": "^2.8.6",
     "@types/jasminewd2": "^2.0.2",
     "@types/node": "^8.9.4",


### PR DESCRIPTION
il s'agit de l'ajout d'un nouveau plugin. pour générer de la documentation, il faut taper. 
> npm run docs:serve

![screen shot 2018-10-15 at 5 32 32 pm](https://user-images.githubusercontent.com/6999749/46979803-99e3fb80-d0a0-11e8-84f2-0e5cffdf6847.png)
![screen shot 2018-10-15 at 5 34 26 pm](https://user-images.githubusercontent.com/6999749/46979804-99e3fb80-d0a0-11e8-8e8a-8d1418991fe0.png)
