### PR TITLE
Desactiver le bouton AJOUTER quand il n'y a pas de fichier uploadé. #56

### DIFF
--- a/src/app/components/add-corpus/add-corpus.component.html
+++ b/src/app/components/add-corpus/add-corpus.component.html
@@ -1,5 +1,4 @@
 <h2 mat-dialog-title>Nouveau texte</h2>
-
 <mat-dialog-content>
   <div>
     <file-drop headertext="Déposer un fichier ici" (onFileDrop)="fileDropped($event)" (onFileOver)="fileOver($event)"
@@ -32,7 +31,10 @@
 </mat-form-field>
 
 <mat-dialog-actions>
-  <button class="btn btn btn-primary" [mat-dialog-close]="data" [disabled]="isValid">Ajouter</button>
+  <button class="btn btn btn-primary" [mat-dialog-close]="data" [disabled]="isNotValid">Ajouter</button>
   <div style="width: 10px"></div>
   <button class="btn btn btn-primary" mat-dialog-close>Annuler</button>
 </mat-dialog-actions>
+<br />
+<mat-progress-bar *ngIf="progress" mode="indeterminate"></mat-progress-bar>
+<span *ngIf="progress" style="color:green">Validation du fichier en cours</span>

--- a/src/app/components/add-corpus/add-corpus.component.ts
+++ b/src/app/components/add-corpus/add-corpus.component.ts
@@ -12,17 +12,22 @@ export class AddCorpusComponent implements OnInit {
   public files: UploadFile[] = [];
   isExtValid = false;
   isSizeValid = false;
-
+  isNotValid: boolean;
+  progress: boolean;
   constructor(
     //  public dialogRef: MatDialogRef<AddCorpusComponent>,
     @Inject(MAT_DIALOG_DATA) public data: any) { }
 
-  ngOnInit() { }
+  ngOnInit() {
+    this.isNotValid = true;
+    this.progress = false;
+  }
 
   public fileDropped(event: UploadEvent) {
     console.log(event);
     this.files = event.files;
-
+    this.isNotValid = true;
+    this.progress = true;
     // la variable info contient le document que l'on veux sauvegarder dans la base de données
     for (const droppedFile of event.files) {
       droppedFile.fileEntry.file(info => {
@@ -33,9 +38,13 @@ export class AddCorpusComponent implements OnInit {
           //Verification du depot de document text
           if (fileExt != "txt") {
             this.isExtValid = true;
+            this.progress = false;
           } else if (info.size == 0) {
+            this.progress = false;
             this.isSizeValid = true;
           } else {
+            this.progress = false;
+            this.isNotValid = false;
             this.isExtValid = false;
           }
         }


### PR DESCRIPTION
Lorsqu'on veut ajouter un nouveau Corpus, il n'y a pas de message d'erreur qui nous demande d'ajouter notre fichier quand on a oublié de le faire. Juste le titre est obligatoire mais le titre seule n'est pas sauvegardé sans l'ajout du fichier. l'ajout du fichier devrait être obligatoire également.
- Désactive le bouton Ajouter quand il n'y a pas de fichier , ajout d'une barre de validation du fichier.
Fait parti du Bug #56 